### PR TITLE
chore(nix): add mold linker to shell.nix to improve linking speeds.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@ let
     pcsclite
     hidapi
     mesa 
+    udev
   ];
 
   packages = with pkgs; [


### PR DESCRIPTION
**Description:** I added [mold](https://github.com/rui314/mold) to required dependencies and set mold as the default linker while compiling the application, in shell.nix

@Lab-8916100448256 @jetcookies  Can you test if you can compile the application and run it in the nix-shell/nix develop?