### PR TITLE
fix #72 : sidebar toggle button redesign

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,13 @@ fn main() {
         gpui_component::init(cx);
         Theme::change(ThemeMode::Dark, None, cx);
 
+        // Register sidebar toggle keybinding
+        cx.bind_keys([gpui::KeyBinding::new(
+            "ctrl-shift-d",
+            ui::rootview::ToggleSidebar,
+            None,
+        )]);
+
         let theme_json = include_str!("../themes/picoforge-zinc.json");
         if let Ok(theme_set) = serde_json::from_str::<ThemeSet>(theme_json) {
             for config in theme_set.themes {
@@ -76,6 +83,7 @@ fn main() {
 
             cx.open_window(window_options, |window, cx| {
                 let view = cx.new(ApplicationRoot::new);
+                window.focus(&view.read(cx).focus_handle());
                 cx.new(|cx| Root::new(view, window, cx))
             })?;
 


### PR DESCRIPTION
This PR implements the proposal of issue #72 : sidebar toggle button redesign

<img width="1344" height="756" alt="image" src="https://github.com/user-attachments/assets/0310542d-aaff-401b-9ddf-014879db474d" />

<img width="1344" height="756" alt="image" src="https://github.com/user-attachments/assets/8cc68cb0-121e-4ed2-b188-3333fb616469" />


