### PR TITLE
fix(ui): sync cached FIDO state after mutations

### DIFF
--- a/src/ui/rootview.rs
+++ b/src/ui/rootview.rs
@@ -60,6 +60,10 @@ impl ApplicationRoot {
 
                 if device_changed {
                     self.views.passkeys = None;
+                } else if let Some(passkeys_view) = &self.views.passkeys {
+                    passkeys_view.update(cx, |view, cx| {
+                        view.refresh_if_unlocked(cx);
+                    });
                 }
 
                 match io::get_fido_info() {
@@ -97,6 +101,8 @@ impl ApplicationRoot {
                 self.device.fido_info = None;
                 self.device.led_status = None;
                 self.device.management_apps = None;
+                // Drop cached passkeys view (and cached PIN) on disconnect.
+                self.views.passkeys = None;
             }
         }
         self.device.loading = false;

--- a/src/ui/views/passkeys.rs
+++ b/src/ui/views/passkeys.rs
@@ -1190,6 +1190,7 @@ impl PasskeysView {
                         cx.emit(PasskeysEvent::Notification(
                             "Device reset successfully".into(),
                         ));
+                        this.lock_storage(cx);
                         this.sync_fido_state(None, cx);
                     }
                     Err(e) => {

--- a/src/ui/views/passkeys.rs
+++ b/src/ui/views/passkeys.rs
@@ -142,19 +142,18 @@ impl PasskeysView {
         let entity = cx.entity().downgrade();
 
         self._task = Some(cx.spawn(async move |_, cx| {
-            let pin_for_bg = pin.clone();
             let result = cx
                 .background_executor()
-                .spawn(async move { io::delete_credential(pin_for_bg, credential_id) })
+                .spawn(async move { io::delete_credential(pin, credential_id) })
                 .await;
 
             let _ = entity.update(cx, |this, cx| match result {
                 Ok(_) => {
                     log::info!("Credential deleted successfully.");
-                    this.refresh_credentials(pin, cx);
                     let _ = dialog_handle.update(cx, |d, cx| {
                         d.set_success("Credential deleted successfully.".to_string(), cx);
                     });
+                    this.sync_fido_state(None, cx);
                 }
                 Err(e) => {
                     log::error!("Error deleting credential: {}", e);
@@ -184,6 +183,46 @@ impl PasskeysView {
                 cx.notify();
             });
         }));
+    }
+
+    /// Re-fetch credentials using the cached PIN (used by sidebar refresh).
+    pub fn refresh_if_unlocked(&mut self, cx: &mut Context<Self>) {
+        if !self.unlocked || self.loading {
+            return;
+        }
+        let Some(pin) = self.cached_pin.clone() else {
+            return;
+        };
+        self.loading = true;
+        cx.notify();
+        self.refresh_credentials(pin, cx);
+    }
+
+    /// Re-sync all cached FIDO state after a mutation.
+    ///
+    /// Refreshes `fido_info`, optionally replaces `cached_pin`, and re-pulls
+    /// credentials when unlocked. `loading` is cleared on completion.
+    fn sync_fido_state(&mut self, new_pin: Option<String>, cx: &mut Context<Self>) {
+        if let Ok(info) = io::get_fido_info() {
+            let _ = self.root.update(cx, |root, cx| {
+                root.device.fido_info = Some(info);
+                cx.notify();
+            });
+        }
+
+        // Only update cached_pin when the caller changed it.
+        if let Some(pin) = new_pin {
+            self.cached_pin = Some(pin);
+        }
+
+        if self.unlocked
+            && let Some(pin) = self.cached_pin.clone()
+        {
+            self.refresh_credentials(pin, cx);
+            return;
+        }
+        self.loading = false;
+        cx.notify();
     }
 
     fn open_unlock_dialog(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -272,29 +311,22 @@ impl PasskeysView {
                 .spawn(async move { io::change_fido_pin(None, new) })
                 .await;
 
-            let _ = entity.update(cx, |this, cx| {
-                this.loading = false;
-                match result {
-                    Ok(msg) => {
-                        log::info!("PIN configured: {}", msg);
-                        if let Ok(info) = io::get_fido_info() {
-                            let _ = this.root.update(cx, |root, cx| {
-                                root.device.fido_info = Some(info);
-                                cx.notify();
-                            });
-                        }
-                        let _ = dialog_handle.update(cx, |d, cx| {
-                            d.set_success("PIN configured successfully.".to_string(), cx);
-                        });
-                    }
-                    Err(e) => {
-                        log::error!("PIN setup failed: {}", e);
-                        let _ = dialog_handle.update(cx, |d, cx| {
-                            d.set_error(format!("Error: {}", e), cx);
-                        });
-                    }
+            let _ = entity.update(cx, |this, cx| match result {
+                Ok(msg) => {
+                    log::info!("PIN configured: {}", msg);
+                    let _ = dialog_handle.update(cx, |d, cx| {
+                        d.set_success("PIN configured successfully.".to_string(), cx);
+                    });
+                    this.sync_fido_state(None, cx);
                 }
-                cx.notify();
+                Err(e) => {
+                    log::error!("PIN setup failed: {}", e);
+                    this.loading = false;
+                    let _ = dialog_handle.update(cx, |d, cx| {
+                        d.set_error(format!("Error: {}", e), cx);
+                    });
+                    cx.notify();
+                }
             });
         }));
     }
@@ -457,6 +489,7 @@ impl PasskeysView {
 
         log::info!("Changing FIDO PIN...");
         let entity = cx.entity().downgrade();
+        let new_for_sync = new.clone();
 
         self._task = Some(cx.spawn(async move |_, cx| {
             let result = cx
@@ -464,29 +497,22 @@ impl PasskeysView {
                 .spawn(async move { io::change_fido_pin(Some(current), new) })
                 .await;
 
-            let _ = entity.update(cx, |this, cx| {
-                this.loading = false;
-                match result {
-                    Ok(msg) => {
-                        log::info!("PIN changed: {}", msg);
-                        if let Ok(info) = io::get_fido_info() {
-                            let _ = this.root.update(cx, |root, cx| {
-                                root.device.fido_info = Some(info);
-                                cx.notify();
-                            });
-                        }
-                        let _ = dialog_handle.update(cx, |d, cx| {
-                            d.set_success("PIN changed successfully.".to_string(), cx);
-                        });
-                    }
-                    Err(e) => {
-                        log::error!("PIN change failed: {}", e);
-                        let _ = dialog_handle.update(cx, |d, cx| {
-                            d.set_error(format!("Error: {}", e), cx);
-                        });
-                    }
+            let _ = entity.update(cx, |this, cx| match result {
+                Ok(msg) => {
+                    log::info!("PIN changed: {}", msg);
+                    let _ = dialog_handle.update(cx, |d, cx| {
+                        d.set_success("PIN changed successfully.".to_string(), cx);
+                    });
+                    this.sync_fido_state(Some(new_for_sync), cx);
                 }
-                cx.notify();
+                Err(e) => {
+                    log::error!("PIN change failed: {}", e);
+                    this.loading = false;
+                    let _ = dialog_handle.update(cx, |d, cx| {
+                        d.set_error(format!("Error: {}", e), cx);
+                    });
+                    cx.notify();
+                }
             });
         }));
     }
@@ -528,51 +554,35 @@ impl PasskeysView {
             }
 
             if !new_pin.is_empty() {
+                let new_pin_for_sync = new_pin.clone();
                 let res_pin = cx
                     .background_executor()
                     .spawn(async move { io::change_fido_pin(Some(current), new_pin) })
                     .await;
-                let _ = entity.update(cx, |this, cx| {
-                    this.loading = false;
-                    match res_pin {
-                        Ok(_) => {
-                            log::info!("Minimum length and PIN updated successfully.");
-                            if let Ok(info) = io::get_fido_info() {
-                                let _ = this.root.update(cx, |root, cx| {
-                                    root.device.fido_info = Some(info);
-                                    cx.notify();
-                                });
-                            }
-                            let _ = status_handle.update(cx, |s, cx| {
-                                s.set_success("Minimum length and PIN updated.".to_string(), cx);
-                            });
-                        }
-                        Err(e) => {
-                            log::error!("Length set, but PIN change failed: {}", e);
-                            let _ = status_handle.update(cx, |s, cx| {
-                                s.set_error(
-                                    format!("Length set, but PIN change failed: {}", e),
-                                    cx,
-                                );
-                            });
-                        }
+                let _ = entity.update(cx, |this, cx| match res_pin {
+                    Ok(_) => {
+                        log::info!("Minimum length and PIN updated successfully.");
+                        let _ = status_handle.update(cx, |s, cx| {
+                            s.set_success("Minimum length and PIN updated.".to_string(), cx);
+                        });
+                        this.sync_fido_state(Some(new_pin_for_sync), cx);
                     }
-                    cx.notify();
+                    Err(e) => {
+                        log::error!("Length set, but PIN change failed: {}", e);
+                        this.loading = false;
+                        let _ = status_handle.update(cx, |s, cx| {
+                            s.set_error(format!("Length set, but PIN change failed: {}", e), cx);
+                        });
+                        cx.notify();
+                    }
                 });
             } else {
                 let _ = entity.update(cx, |this, cx| {
-                    this.loading = false;
                     log::info!("Minimum PIN length updated to {}.", min_len);
-                    if let Ok(info) = io::get_fido_info() {
-                        let _ = this.root.update(cx, |root, cx| {
-                            root.device.fido_info = Some(info);
-                            cx.notify();
-                        });
-                    }
                     let _ = status_handle.update(cx, |s, cx| {
                         s.set_success(format!("Minimum length updated to {}.", min_len), cx);
                     });
-                    cx.notify();
+                    this.sync_fido_state(None, cx);
                 });
             }
         }));
@@ -706,29 +716,22 @@ impl PasskeysView {
                 .spawn(async move { io::enable_enterprise_attestation(pin) })
                 .await;
 
-            let _ = entity.update(cx, |this, cx| {
-                this.loading = false;
-                match result {
-                    Ok(msg) => {
-                        log::info!("{}", msg);
-                        if let Ok(info) = io::get_fido_info() {
-                            let _ = this.root.update(cx, |root, cx| {
-                                root.device.fido_info = Some(info);
-                                cx.notify();
-                            });
-                        }
-                        let _ = dialog_handle.update(cx, |d, cx| {
-                            d.set_success(msg, cx);
-                        });
-                    }
-                    Err(e) => {
-                        log::error!("Failed to enable EA: {}", e);
-                        let _ = dialog_handle.update(cx, |d, cx| {
-                            d.set_error(format!("Error: {}", e), cx);
-                        });
-                    }
+            let _ = entity.update(cx, |this, cx| match result {
+                Ok(msg) => {
+                    log::info!("{}", msg);
+                    let _ = dialog_handle.update(cx, |d, cx| {
+                        d.set_success(msg, cx);
+                    });
+                    this.sync_fido_state(None, cx);
                 }
-                cx.notify();
+                Err(e) => {
+                    log::error!("Failed to enable EA: {}", e);
+                    this.loading = false;
+                    let _ = dialog_handle.update(cx, |d, cx| {
+                        d.set_error(format!("Error: {}", e), cx);
+                    });
+                    cx.notify();
+                }
             });
         }));
     }
@@ -1177,7 +1180,6 @@ impl PasskeysView {
                 .await;
 
             let _ = entity.update(cx, |this, cx| {
-                this.loading = false;
                 match result {
                     Ok(msg) => {
                         log::info!("Device Reset: {}", msg);
@@ -1188,15 +1190,17 @@ impl PasskeysView {
                         cx.emit(PasskeysEvent::Notification(
                             "Device reset successfully".into(),
                         ));
+                        this.sync_fido_state(None, cx);
                     }
                     Err(e) => {
                         log::error!("Error resetting device: {}", e);
+                        this.loading = false;
                         let _ = status_handle.update(cx, |d, cx| {
                             d.set_error(format!("Reset failed: {}", e), cx);
                         });
+                        cx.notify();
                     }
                 }
-                cx.notify();
             });
         }));
     }


### PR DESCRIPTION
### Checklist

  - [x] Code compiles without errors
  - [x] Code is formatted using `cargo fmt`
  - [x] All tests are passing
  - [ ] Extended the documentation with the changes made in the code
  - [ ] Added myself to the CREDITS.md file
  - [ ] Requested review from one of the maintainers

  ### Description

  At first I was annoyed that I had to lock and unlock in order to see newly created passkeys, then I realized the same continues after factory reset; the PIN row still said "Change PIN" even though the device had been wiped. That's when it clicked that all these symptoms were really the same bug: the app caches FIDO state (`fido_info`, `credentials`, `cached_pin`) and each mutating operation only refreshed a different part of it, so something always went stale.

  Digging deeper turned up more of the same: changing the PIN left `cached_pin` holding the old value, so the next delete silently failed with an auth error; deleting a passkey didn't update the "Remaining Credentials" count on the Home view; and the cached PIN/unlocked state lingered in memory even after the device was unplugged. All of them traced back to the same root cause — there was no single "re-sync after mutation" path.

  ### Proposed changes

  - Replace the scattered `io::get_fido_info()` and `refresh_credentials()` calls with one `sync_fido_state()` function called from every mutating op's success branch (`setup_pin`, `change_pin`, `update_min_length`, `enable_ea`, `execute_delete`, `reset`).
  - Sidebar Refresh now calls `refresh_if_unlocked` on the existing `PasskeysView` when the device serial is unchanged, so passkeys created externally (e.g. via browser) appear without requiring lock/unlock.
  - After factory reset, `fido_info` is re-pulled so the PIN row flips from "Change PIN" to "Set up PIN" without a manual refresh.
  - After changing the PIN, `cached_pin` is updated before the credentials re-fetch uses it, so deleting a passkey no longer fails with a stale-pin auth error.
  - After deleting a passkey, `fido_info` is refreshed so the Home "Remaining Credentials" count stays accurate.
  - Drop the cached `PasskeysView` (and its cached PIN) when the device is unplugged, so unlocked state does not linger in memory with no device attached.

  This should be accepted because it fixes all reported stale-state symptoms from one root cause, removes duplicated refresh logic, and adds no new blocking I/O on the UI thread beyond what the existing ops already did.

  ### Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [x] Refactoring / Code style change
  - [ ] Add packaging for a new platform

  ### UI Changes (Optional)

  - Screenshots / Videos: N/A