### PR TITLE
ci: update nix channel and action versions

### DIFF
--- a/.github/workflows/nix-binary-cache.yml
+++ b/.github/workflows/nix-binary-cache.yml
@@ -5,33 +5,21 @@ on:
       - main
     paths:
       - package.nix
-  schedule:
-    - cron:  '45 3 * * *'
   workflow_dispatch:
 jobs:
-  tests:
+  build:
     strategy:
       matrix:
-        # Set this to cache your build results in cachix for faster builds
-        # in CI and for everyone who uses your cache.
-        #
-        # Format: Your cachix cache host name without the ".cachix.org" suffix.
-        # Example: mycache (for mycache.cachix.org)
-        #
-        # For this to work, you also need to set the CACHIX_SIGNING_KEY or
-        # CACHIX_AUTH_TOKEN secret in your repository secrets settings in
-        # Github found at
-        # https://github.com/<your_githubname>/nur-packages/settings/secrets
         cachixName:
           - librekeys
         nixPath:
           - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz
           - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz
-          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-25.11.tar.gz
+          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-26.05.tar.gz
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install nix
       uses: cachix/install-nix-action@v31
       with:
@@ -42,7 +30,7 @@ jobs:
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Setup cachix
-      uses: cachix/cachix-action@v16
+      uses: cachix/cachix-action@v17
       # Don't replace <YOUR_CACHIX_NAME> here!
       if: ${{ matrix.cachixName != '<YOUR_CACHIX_NAME>' }}
       with:

--- a/.github/workflows/nix-check-package.yml
+++ b/.github/workflows/nix-check-package.yml
@@ -12,11 +12,11 @@ jobs:
         nixPath:
           - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz
           - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz
-          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-25.11.tar.gz
+          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-26.05.tar.gz
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install nix
       uses: cachix/install-nix-action@v31
       with:
@@ -27,7 +27,7 @@ jobs:
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Setup cachix
-      uses: cachix/cachix-action@v16
+      uses: cachix/cachix-action@v17
       with:
         name: ${{ matrix.cachixName }}
     - name: Check evaluation

--- a/.github/workflows/nix-update-package.yml
+++ b/.github/workflows/nix-update-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install nix
       uses: cachix/install-nix-action@v31
       with:
@@ -26,7 +26,7 @@ jobs:
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Update flake packages
-      uses: gepbird/nix-update-action@v2.1.1
+      uses: gepbird/nix-update-action@v3.1.0
       with:
         token: ${{ secrets.NIX_UPDATE_TOKEN }}
         blacklist: "default"


### PR DESCRIPTION
<!--PicoForge Pull Request Template-->

> [!NOTE]
> Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository before proceeding. Check [README.md](../README.md) to get more info of the project.

### Checklist

- [x] Code compiles without errors
- [ ] Code is formatted using `cargo fmt`
- [ ] All tests are passing (skip if no tests exist)
- [ ] Extended the documentation with the changes made in the code (Optional)
- [x] Added myself to the CREDITS.md file
- [x] Requested review from one of the maintainers

### Description

Update the nixpkgs input channel from `nixos-25.11` to `nixos-26.05` across all three CI workflows, and bump several GitHub Actions to their latest available versions. Also removes the stale `schedule` trigger from the binary-cache workflow, since `push` to `main` already covers the same cache builds and the schedule was causing redundant runs.

### Proposed changes

Keeps the CI pipeline aligned with the current nixpkgs stable channel and eliminates deprecation warnings from outdated action versions. Removing the duplicate trigger reduces unnecessary CI time and cache uploads.

### Types of changes

- [x] CI workflow update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code style change
- [ ] Add packaging for a new platform

### UI Changes (Optional)

N/A — CI workflow changes only.
